### PR TITLE
Run and publish main components on Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: Playwright Tests
 on:
   push:
-    branches: [ main, master ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, master ]
+    branches: [ main ]
   repository_dispatch:
     types: [ opus-ui-tagged ]
 jobs:
@@ -11,10 +11,17 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Checkout dispatched release branch
+        if: github.event_name == 'repository_dispatch'
+        uses: actions/checkout@v6
         with:
-          node-version: lts/*
+          ref: ${{ github.event.client_payload.ref == 'refs/heads/opus-2' && 'opus-2' || 'main' }}
+      - name: Checkout current ref
+        if: github.event_name != 'repository_dispatch'
+        uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
       - name: Install dependencies
         run: npm ci
       - name: Install Playwright Browsers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,5 @@
 name: Playwright Tests
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
   repository_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         if: github.event_name == 'repository_dispatch'
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.client_payload.ref == 'refs/heads/opus-2' && 'opus-2' || 'main' }}
+          ref: ${{ (github.event.client_payload.target_branch == 'opus-2' || github.event.client_payload.ref == 'refs/heads/opus-2') && 'opus-2' || 'main' }}
       - name: Checkout current ref
         if: github.event_name != 'repository_dispatch'
         uses: actions/checkout@v6

--- a/.github/workflows/createTags.yml
+++ b/.github/workflows/createTags.yml
@@ -5,15 +5,23 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   create-tag:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           # Fetch the full history so that git tags can be pushed correctly.
           fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
 
       - name: Get package version
         id: get_version
@@ -26,7 +34,6 @@ jobs:
       - name: Create and push tag if not exists
         env:
           PACKAGE_VERSION: ${{ env.VERSION }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "GitHub Action"
           git config user.email "action@github.com"

--- a/.github/workflows/createTags.yml
+++ b/.github/workflows/createTags.yml
@@ -1,4 +1,4 @@
-name: Create Tag
+name: Test, Build, Publish, and Tag
 
 on:
   push:
@@ -7,29 +7,48 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
-  create-tag:
+  build-publish-tag:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          # Fetch the full history so that git tags can be pushed correctly.
           fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
 
       - name: Get package version
         id: get_version
         run: |
-          # Extract the version from package.json
           VERSION=$(node -p "require('./package.json').version")
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "Detected version: $VERSION"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright
+        run: npx playwright install chromium
+
+      - name: Run Playwright tests
+        run: npx playwright test
+
+      - name: Build project
+        run: npm run build
+
+      - name: Publish to npm
+        run: |
+          echo "Publishing version $VERSION to npm..."
+          npm publish
 
       - name: Create and push tag if not exists
         env:
@@ -37,8 +56,7 @@ jobs:
         run: |
           git config user.name "GitHub Action"
           git config user.email "action@github.com"
-          
-          # Check if the tag already exists
+
           if git tag --list "v${PACKAGE_VERSION}" | grep -q "v${PACKAGE_VERSION}"; then
             echo "Tag v${PACKAGE_VERSION} already exists. Doing nothing."
           else

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@intenda/opus-ui-components",
-	"version": "3.2.1",
+	"version": "3.2.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@intenda/opus-ui-components",
-			"version": "3.2.1",
+			"version": "3.2.2",
 			"dependencies": {
 				"keen-slider": "^6.8.6",
 				"material-icons": "^1.13.14",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,12 @@
 {
 	"name": "@intenda/opus-ui-components",
-	"version": "3.2.1",
+	"version": "3.2.2",
 	"type": "module",
 	"homepage": "https://opus-ui.com",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/IntendaUK/opus-ui-components"
+	},
 	"files": [
 		"dist",
 		"lspconfig.json"


### PR DESCRIPTION
## What changed

- upgrade `actions/checkout` and `actions/setup-node` to v6 and run component workflows on Node.js 24
- make dispatched compatibility tests select `opus-2` when explicitly targeted, otherwise `main`
- keep the standalone Playwright workflow for pull requests and repository dispatches, but stop rerunning it separately on main pushes
- replace the tag-only main workflow with a single test → build → npm publish → Git tag release workflow
- publish `@intenda/opus-ui-components@3.2.2` to npm's default `latest` channel through Trusted Publishing (OIDC)
- add the repository metadata required for npm provenance verification
- create `v3.2.2` only after a successful npm publish
- grant explicit OIDC and tag-push permissions and disable release-job package-manager caching

## Why

GitHub was warning about deprecated Node.js action runtimes, dispatched tests always started from the components default branch, and component releases did not use the same validated trusted-publishing sequence as Opus UI. Pushes also ran Playwright independently from tagging rather than making tests a prerequisite for publication.

## Impact

Pull requests and Opus UI compatibility dispatches run Playwright without publishing. A merge or direct push to `main` runs Playwright once, builds, publishes 3.2.2 with provenance, and pushes `v3.2.2` only after publication succeeds.

## npm prerequisite

Before merging, configure the npm Trusted Publisher for `@intenda/opus-ui-components` with organization `IntendaUK`, repository `opus-ui-components`, workflow `createTags.yml`, and permission to run `npm publish`.

## Validation

- confirmed npm currently reports 3.2.1 as `latest`, so 3.2.2 is available
- parsed all workflow YAML and package JSON successfully
- verified the package version and repository metadata through `npm pkg get`
- ran `git diff --check`
- the PR's Node.js 24 Playwright workflow will rerun after this update