### PR TITLE
Run and publish Opus 2 components on Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,18 @@
 name: Playwright Tests
 on:
   push:
-    branches: [ main, master ]
+    branches: [ opus-2 ]
   pull_request:
-    branches: [ main, master ]
-  repository_dispatch:
-    types: [ opus-ui-tagged ]
+    branches: [ opus-2 ]
 jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          node-version: '24'
       - name: Install dependencies
         run: npm ci
       - name: Install Playwright Browsers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,5 @@
 name: Playwright Tests
 on:
-  push:
-    branches: [ opus-2 ]
   pull_request:
     branches: [ opus-2 ]
 jobs:

--- a/.github/workflows/createTags.yml
+++ b/.github/workflows/createTags.yml
@@ -1,4 +1,4 @@
-name: Create Tag
+name: Test, Build, Publish, and Tag
 
 on:
   push:
@@ -7,29 +7,48 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
-  create-tag:
+  build-publish-tag:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          # Fetch the full history so that git tags can be pushed correctly.
           fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
 
       - name: Get package version
         id: get_version
         run: |
-          # Extract the version from package.json
           VERSION=$(node -p "require('./package.json').version")
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "Detected version: $VERSION"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright
+        run: npx playwright install chromium
+
+      - name: Run Playwright tests
+        run: npx playwright test
+
+      - name: Build project
+        run: npm run build
+
+      - name: Publish to npm
+        run: |
+          echo "Publishing version $VERSION to npm with the opus-2 tag..."
+          npm publish --tag opus-2
 
       - name: Create and push tag if not exists
         env:
@@ -37,8 +56,7 @@ jobs:
         run: |
           git config user.name "GitHub Action"
           git config user.email "action@github.com"
-          
-          # Check if the tag already exists
+
           if git tag --list "v${PACKAGE_VERSION}" | grep -q "v${PACKAGE_VERSION}"; then
             echo "Tag v${PACKAGE_VERSION} already exists. Doing nothing."
           else

--- a/.github/workflows/createTags.yml
+++ b/.github/workflows/createTags.yml
@@ -3,17 +3,25 @@ name: Create Tag
 on:
   push:
     branches:
-      - main
+      - opus-2
+
+permissions:
+  contents: write
 
 jobs:
   create-tag:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           # Fetch the full history so that git tags can be pushed correctly.
           fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
 
       - name: Get package version
         id: get_version
@@ -26,7 +34,6 @@ jobs:
       - name: Create and push tag if not exists
         env:
           PACKAGE_VERSION: ${{ env.VERSION }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "GitHub Action"
           git config user.email "action@github.com"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@intenda/opus-ui-components",
-	"version": "2.11.1",
+	"version": "2.11.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@intenda/opus-ui-components",
-			"version": "2.11.1",
+			"version": "2.11.2",
 			"dependencies": {
 				"@mona-health/react-input-mask": "3.0.3",
 				"keen-slider": "^6.8.6",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,12 @@
 {
 	"name": "@intenda/opus-ui-components",
-	"version": "2.11.1",
+	"version": "2.11.2",
 	"type": "module",
 	"homepage": "https://opus-ui.com",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/IntendaUK/opus-ui-components"
+	},
 	"files": [
 		"dist",
 		"lspconfig.json"


### PR DESCRIPTION
## What changed

- make Opus 2 component pull requests target `opus-2` and run Playwright on Node.js 24
- keep standalone Playwright CI PR-only so a release push does not run the test suite twice
- replace the tag-only Opus 2 workflow with a single test → build → npm publish → Git tag release workflow
- publish `@intenda/opus-ui-components@2.11.2` through Trusted Publishing (OIDC) using the npm `opus-2` dist-tag
- add the repository metadata required for npm provenance verification
- create `v2.11.2` only after a successful npm publish
- update all affected actions to v6, grant explicit OIDC/tag permissions, and disable release-job package-manager caching
- leave repository dispatch handling in the default-branch workflow, which checks out this Opus 2 branch when targeted

## Why

The Opus 2 workflows targeted the wrong release branch, used deprecated Node.js action runtimes, and only created Git tags without first testing, building, and publishing the npm package. This aligns the release behavior with Opus UI while preserving Opus 3 as npm's `latest` channel.

## Impact

Opus 2 component pull requests run Playwright without publishing. A merge or direct push to `opus-2` runs Playwright once, builds, publishes 2.11.2 with provenance under the `opus-2` npm dist-tag, and pushes `v2.11.2` only after publication succeeds.

## npm prerequisite

Before merging, configure the npm Trusted Publisher for `@intenda/opus-ui-components` with organization `IntendaUK`, repository `opus-ui-components`, workflow `createTags.yml`, and permission to run `npm publish`. The same trusted-publisher entry covers both release branches.

## Validation

- confirmed npm currently contains 2.11.1 and does not contain 2.11.2
- parsed all workflow YAML and package JSON successfully
- verified the package version and repository metadata through `npm pkg get`
- ran `git diff --check`
- the PR's Node.js 24 Playwright workflow will rerun after this update