### PR TITLE
Skip already-published Opus 2 component versions

### DIFF
--- a/.github/workflows/createTags.yml
+++ b/.github/workflows/createTags.yml
@@ -45,10 +45,21 @@ jobs:
       - name: Build project
         run: npm run build
 
-      - name: Publish to npm
+      - name: Publish to npm if version is new
         run: |
-          echo "Publishing version $VERSION to npm with the opus-2 tag..."
-          npm publish --tag opus-2
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          PACKAGE_SPEC="${PACKAGE_NAME}@${VERSION}"
+
+          if npm view "$PACKAGE_SPEC" version --json >/dev/null 2>&1; then
+            echo "$PACKAGE_SPEC is already published. Skipping npm publish."
+          elif npm publish --tag opus-2; then
+            echo "Published $PACKAGE_SPEC with the opus-2 tag."
+          elif npm view "$PACKAGE_SPEC" version --json >/dev/null 2>&1; then
+            echo "$PACKAGE_SPEC was published by another workflow. Continuing."
+          else
+            echo "Failed to publish $PACKAGE_SPEC."
+            exit 1
+          fi
 
       - name: Create and push tag if not exists
         env:


### PR DESCRIPTION
## What changed

- check npm for the exact `@intenda/opus-ui-components` version before attempting the Opus 2 publication
- skip `npm publish --tag opus-2` successfully when that version already exists
- recheck npm after a publish failure to handle concurrent workflows racing to publish the same version
- continue to the existing idempotent Git tag step when publication is skipped
- retain failures for genuine authentication, registry, or publish errors when the version does not exist

## Why

Every push to `opus-2` runs the combined release workflow. Workflow-only commits should not fail merely because component version 2.11.2 was already published.

## Impact

Repeated release workflow runs for an unchanged Opus 2 component version complete successfully without attempting to overwrite npm. New versions still publish under the `opus-2` dist-tag, and `vX.Y.Z` tags are still created after the version is confirmed on npm.

## Validation

- parsed the workflow YAML successfully
- ran `git diff --check`
- confirmed 2.11.2 already exists on npm, exercising the intended skip condition conceptually
- the PR's Node.js 24 Playwright workflow validates the codebase independently