### PR TITLE
Test releases against latest Opus UI

### DIFF
--- a/.github/workflows/createTags.yml
+++ b/.github/workflows/createTags.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install latest Opus UI for tests
+        run: npm update @intenda/opus-ui --no-save --package-lock=false
+
       - name: Install Playwright
         run: npx playwright install chromium
 


### PR DESCRIPTION
## What changed

The release workflow now updates the test environment to the latest compatible `@intenda/opus-ui` after the lockfile-based install.

## Why

The components package lockfile installs Opus UI 3.0.1, while the newly merged treeview implementation requires the `renderWgts` export introduced in Opus UI 3.1.6. The pull-request workflow was updated before merge, but the separate release workflow still tested against the locked version and prevented 3.2.3 from publishing.

## Impact

Release tests run against the latest compatible Opus UI without modifying the committed lockfile. Once the tests pass, the existing workflow can build, publish, and tag version 3.2.3.

## Validation

Verified locally that `npm update @intenda/opus-ui --no-save --package-lock=false` updates the test installation from 3.0.1 to 3.1.6 and provides `renderWgts`.
